### PR TITLE
Refactor history creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ export default {
 
 ```javascript
 // main.js
-import { createHistory } from 'svelte-routing';
+import { createBrowserHistory } from 'svelte-routing';
 import App from './App.html';
 
-createHistory('browser');
+createBrowserHistory();
 
 const app = new App({
   target: document.getElementById('app'),
@@ -60,11 +60,11 @@ const app = new App({
 ```javascript
 // server.js
 const { createServer } = require('http');
-const { createHistory } = require('svelte-routing');
+const { createMemoryHistory } = require('svelte-routing');
 require('svelte/ssr/register');
 const app = require('./App.html');
 
-const history = createHistory('memory');
+const history = createMemoryHistory();
 
 createServer((req, res) => {
   history.replace(req.url);
@@ -81,21 +81,25 @@ createServer((req, res) => {
 
 ## API
 
-#### `createHistory`
+#### `createBrowserHistory`, `createMemoryHistory`, `createHashHistory`
 
-A function that initializes the history object.
+Functions that initializes the history object.
 
 ```javascript
-import { createHistory } from 'svelte-routing';
+import {
+  createBrowserHistory,
+  createMemoryHistory,
+  createHashHistory
+} from 'svelte-routing';
 
 // Browser history is for use in modern web browsers that support the HTML5 history API
-const history = createHistory('browser');
+const history = createBrowserHistory();
 
 // Memory history is for use in non-DOM environments, like the server and tests
-const history = createHistory('memory');
+const history = createMemoryHistory();
 
 // Hash history is for use in legacy web browsers
-const history = createHistory('hash');
+const history = createHashHistory();
 ```
 
 #### `Link.html`

--- a/example/main.js
+++ b/example/main.js
@@ -1,7 +1,7 @@
-import { createHistory } from 'svelte-routing';
+import { createBrowserHistory } from 'svelte-routing';
 import App from './App.html';
 
-createHistory('browser');
+createBrowserHistory();
 
 const app = new App({
   target: document.getElementById('app'),

--- a/example/server.js
+++ b/example/server.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const express = require('express');
-const { createHistory } = require('svelte-routing');
+const { createMemoryHistory } = require('svelte-routing');
 const app = require('./App.html');
 
-const history = createHistory('memory');
+const history = createMemoryHistory();
 const server = express();
 
 server.use(express.static(path.join(__dirname, 'dist')));

--- a/index.js
+++ b/index.js
@@ -1,25 +1,12 @@
-import createMemoryHistory from 'history/es/createMemoryHistory';
-import createHashHistory from 'history/es/createHashHistory';
-import createBrowserHistory from 'history/es/createBrowserHistory';
+import memoryHistory from 'history/es/createMemoryHistory';
+import hashHistory from 'history/es/createHashHistory';
+import browserHistory from 'history/es/createBrowserHistory';
 
 let history;
 
-const createHistory = type => {
-  switch (type) {
-    case 'memory':
-      history = createMemoryHistory();
-      break;
-    case 'hash':
-      history = createHashHistory();
-      break;
-    case 'browser':
-    default:
-      history = createBrowserHistory();
-      break;
-  }
-
-  return history;
-};
+const createMemoryHistory = () => history = memoryHistory();
+const createHashHistory = () => history = hashHistory();
+const createBrowserHistory = () => history = browserHistory();
 
 const getHistory = () => history;
 
@@ -30,4 +17,10 @@ const isModifiedEvent = event => {
 };
 
 export { matchPath } from './matchPath.js';
-export { getHistory, createHistory, isModifiedEvent };
+export {
+  createMemoryHistory,
+  createHashHistory,
+  createBrowserHistory,
+  getHistory,
+  isModifiedEvent
+};


### PR DESCRIPTION
Because of the way history creation is currently implemented, Rollup/Webpack can't tree shake off unused history creation code. By splitting  `createHistory` into  `createBrowserHistory`, `createMemoryHistory`,  and `createHashHistory`, large amounts of unused code can be removed.

This is a breaking change, so best to wait with it until `1.0.0`.