### PR TITLE
Dynamically pass props to Route components

### DIFF
--- a/Route.html
+++ b/Route.html
@@ -1,6 +1,6 @@
 {#if match !== null}
   {#if component !== null}
-    <svelte:component this={component} match={match}/>
+    <svelte:component this={component} match={match} {...props} />
   {:else}
     <slot></slot>
   {/if}
@@ -8,6 +8,8 @@
 
 <script>
 import { getHistory, matchPath } from './index.js';
+
+const defaultData = ['match', 'pathname', 'path', 'exact', 'strict', 'component', 'props', 'history'];
 
 export default {
   data() {
@@ -19,12 +21,31 @@ export default {
       exact: false,
       strict: false,
       component: null,
+      props: {},
       history
     };
   },
   computed: {
     match: ({ pathname, path, exact, strict }) => {
       return matchPath(pathname, { path, exact, strict });
+    }
+  },
+  onstate({changed, current, previous}) {
+    const propsChanged = Object.keys(changed).reduce((propsChanged, prop) => {
+      if (propsChanged) return true;
+      if (defaultData.indexOf(prop) === -1) return true;
+      return false;
+    }, false);
+
+    if (propsChanged) {
+      const data = this.get();
+      const props = {};
+
+      Object.keys(data).forEach(key => {
+        if (defaultData.indexOf(key) === -1) props[key] = data[key];
+      });
+
+      this.set({ props });
     }
   },
   oncreate() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-routing",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A Svelte routing library with SSR support",
   "main": "index.js",
   "author": "Emil Tholin @tholle1234",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-routing",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A Svelte routing library with SSR support",
   "main": "index.js",
   "author": "Emil Tholin @tholle1234",


### PR DESCRIPTION
This change makes it so that any custom prop passed to `<Route />` will propagate to the rendered component. I think this could have a lot of use-cases, but I specifically use it to code split routes. For example:

```html
<Route path="/admin/users" component={Bundle} load={load} />

<script>
import Bundle from './Bundle.html';

export default {
  data() {
    return {
      Bundle,
      load: function () {
        // lazy load the route component
        return import('./Users.html')
      }
    }
  }
}
</script>
```