### PR TITLE
fixed a links when having children

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -12,7 +12,7 @@ import { shouldNavigate } from "./utils.js";
  */
 function link(node) {
   function onClick(event) {
-    const anchor = event.target;
+    const anchor = event.target.closest('a');
 
     if (
       anchor.target === "" &&

--- a/src/actions.js
+++ b/src/actions.js
@@ -12,7 +12,7 @@ import { shouldNavigate } from "./utils.js";
  */
 function link(node) {
   function onClick(event) {
-    const anchor = event.target.closest('a');
+    const anchor = event.currentTarget;
 
     if (
       anchor.target === "" &&


### PR DESCRIPTION
Fixed <a href="' use:link> when having children. 

Previously `<a href="" use:link>just text</a>` worked, but not when having something like:
`<a href="" use:link><span>Label</span><span class="icon"></span</a>`