### PR TITLE
Pass params to slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ All properties other than `path` and `component` given to the `Route` will be pa
 
 Potential route parameters will be passed to the rendered `component` as properties. A wildcard `*` can be given a name with `*wildcardName` to pass the wildcard string as the `wildcardName` property instead of as the `*` property.
 
+Potential route parameters are passed back to the parent using props, so they can be exposed to the slot template using `let:params`.
+
+```html
+<Route path="blog/:id" let:params>
+  <BlogPost id="{params.id}" />
+</Route>
+```
+
 ###### Properties
 
 |  Property   | Required | Default Value | Description                                                                                                                                                              |

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -40,6 +40,6 @@
   {#if component !== null}
     <svelte:component this="{component}" {...routeParams} {...routeProps} />
   {:else}
-    <slot></slot>
+    <slot {routeProps} {routeParams}></slot>
   {/if}
 {/if}

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -40,6 +40,6 @@
   {#if component !== null}
     <svelte:component this="{component}" {...routeParams} {...routeProps} />
   {:else}
-    <slot {routeProps} {routeParams}></slot>
+    <slot props={{ ...routeProps, ...routeParams }}></slot>
   {/if}
 {/if}

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -40,6 +40,6 @@
   {#if component !== null}
     <svelte:component this="{component}" {...routeParams} {...routeProps} />
   {:else}
-    <slot props={{ ...routeProps, ...routeParams }}></slot>
+    <slot params="{routeParams}"></slot>
   {/if}
 {/if}


### PR DESCRIPTION
Hello,

I'm using this library with svelte-loadable, and for that I need to get the route params down to the imported component, like so:
```html
<Route path="/user/:id" let:props={params}>
  <Loadable {...params} loader={() => import('./components/EditUser.svelte')} />
</Route>
```

And to do that I need to use the slot, not the component, with props