### PR TITLE
Added support for queryString params.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "repository": "EmilTholin/svelte-routing",
   "peerDependencies": {
     "svelte": "3.x"
+  },
+  "dependencies": {
+    "query-string": "^6.8.2"
   }
 }

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -55,6 +55,7 @@
     // it when the basepath changes. The only thing that matters is that
     // the route reference is intact, so mutation is fine.
     route._path = path;
+    [path, route.search] = path.split('?', 2);
     route.path = combinePaths(basepath, path);
 
     if (typeof window === "undefined") {
@@ -65,7 +66,7 @@
         return;
       }
 
-      const matchingRoute = match(route, $location.pathname);
+      const matchingRoute = match(route, $location.pathname, $location.search);
       if (matchingRoute) {
         activeRoute.set(matchingRoute);
         hasActiveRoute = true;
@@ -100,7 +101,7 @@
   // will not find an active Route in SSR and in the browser it will only
   // pick an active Route after all Routes have been registered.
   $: {
-    const bestMatch = pick($routes, $location.pathname);
+    const bestMatch = pick($routes, $location.pathname, $location.search);
     activeRoute.set(bestMatch);
   }
 


### PR DESCRIPTION
I also needed query parameters as in #26, so I added this functionality. 

- it depends on query-string
- you can specify route in `<Route>`, e.g.:
```html
<Route path="/app/search?statusFilter=:statusFilter|new" component="{Messages}" />
```

The `|new` means that if the query param is not present, 'new' is used as a default value (as opposed to undefined). This is somewhat useful when you navigate between the pages, the default value set in the component was already reset and so would become undefined instead, which may not be desired.

I'm very unexperienced in JS, so feel free to criticize :)