### PR TITLE
fix: Reset focus after route

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -54,6 +54,7 @@ function createHistory(source, options) {
 
       location = getLocation(source);
       listeners.forEach(listener => listener({ location, action: "PUSH" }));
+      document.activeElement.blur();
     }
   };
 }


### PR DESCRIPTION
(This addresses #25 partly)

This returns focus back to <body>, which, while not ideal, is what would happen in a non-SPA.

For users of screenreaders, I'd say this is better than doing nothing at all.

As I mentioned in #25, I see this as a first step, with the second step being a mechanism to move focus intentionally (and/or something that automates it, as found in [Reach](https://github.com/reach/router/blob/master/src/index.js#L266-L381)).