### PR TITLE
Preserve query in the `link` action

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -20,7 +20,7 @@ function link(node) {
       shouldNavigate(event)
     ) {
       event.preventDefault();
-      navigate(anchor.pathname, { replace: anchor.hasAttribute("replace") });
+      navigate(anchor.pathname + anchor.search, { replace: anchor.hasAttribute("replace") });
     }
   }
 


### PR DESCRIPTION
Closes #79 

This was super annoying and so easy to fix.