### PR TITLE
Update Readme Usage Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ npm install --save svelte-routing
     <Link to="blog">Blog</Link>
   </nav>
   <div>
-    <Route path="blog/:id" component="{BlogPost}" />
-    <Route path="blog" component="{Blog}" />
+    <Route path="blog/*" component="{Blog}" />
     <Route path="about" component="{About}" />
     <Route path="/"><Home /></Route>
   </div>


### PR DESCRIPTION
👋🏻 I was having a couple of issues with the readme example. First there isn't a "BlogPost" component so the compiler was throwing an error, and then I couldn't see the blogposts in the Blog component when clicking one in the blog page. After looking at the example App.svelte I spotted the discrepancy relating to using the "/:id" in the current readme vs a wildcard like in the example and I was able to get it working!

Hope this helps! Thanks!