### PR TITLE
fix use:link and use:links for ie11.  anchor.host was empty in ie11

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,5 @@
 import { navigate } from "./history.js";
-import { shouldNavigate } from "./utils.js";
+import { shouldNavigate, hostMatches } from "./utils.js";
 
 /**
  * A link action that can be added to <a href=""> tags rather
@@ -16,7 +16,7 @@ function link(node) {
 
     if (
       anchor.target === "" &&
-      anchor.host === location.host &&
+      hostMatches(anchor) &&
       shouldNavigate(event)
     ) {
       event.preventDefault();
@@ -64,7 +64,7 @@ function links(node) {
     if (
       anchor &&
       anchor.target === "" &&
-      anchor.host === location.host &&
+      hostMatches(anchor) &&
       shouldNavigate(event) &&
       !anchor.hasAttribute("noroute")
     ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -335,8 +335,8 @@ function hostMatches(anchor) {
   return (
     anchor.host == host ||
     // svelte seems to kill anchor.host value in ie11, so fall back to checking href
-    anchor.href.indexOf(`https://${host}`) == 0 ||
-    anchor.href.indexOf(`http://${host}`) == 0
+    anchor.href.indexOf(`https://${host}`) === 0 ||
+    anchor.href.indexOf(`http://${host}`) === 0
   )
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -330,4 +330,14 @@ function shouldNavigate(event) {
   );
 }
 
-export { stripSlashes, pick, match, resolve, combinePaths, shouldNavigate };
+function hostMatches(anchor) {
+  const host = location.host
+  return (
+    anchor.host == host ||
+    // svelte seems to kill anchor.host value in ie11, so fall back to checking href
+    anchor.href.indexOf(`https://${host}`) == 0 ||
+    anchor.href.indexOf(`http://${host}`) == 0
+  )
+}
+
+export { stripSlashes, pick, match, resolve, combinePaths, shouldNavigate, hostMatches };


### PR DESCRIPTION
Seems anchor.host is empty in ie11.  Fall back to checking href.

Went through the hassle of making our svelte project work in IE11, and this was the only issue we ran into w/ this library.
