### PR TITLE
Link: pass additional attributes/props down to <a> element

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "repository": "EmilTholin/svelte-routing",
   "peerDependencies": {
-    "svelte": "3.x"
+    "svelte": "^3.20.x"
   }
 }

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -38,6 +38,6 @@
   }
 </script>
 
-<a href="{href}" aria-current="{ariaCurrent}" on:click="{onClick}" {...props}>
+<a href="{href}" aria-current="{ariaCurrent}" on:click="{onClick}" {...props} {...$$restProps}>
   <slot></slot>
 </a>


### PR DESCRIPTION
This passes additional attributes specified in `<Link>` down to the corresponding `<a>` element. It does not affect the exports in any way. This requires svelte 3.20+.

#### Example
##### Svelte:
```
<Link to="/blog" class="underline">Blog</Link>
```
##### Rendered:
```
<a href="/blog" class="underline">Blog</a>
```