### PR TITLE
Allow passing custom History object

### DIFF
--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getContext, createEventDispatcher } from "svelte";
-  import { ROUTER, LOCATION } from "./contexts.js";
-  import { navigate } from "./history.js";
+  import { ROUTER, LOCATION, HISTORY } from "./contexts.js";
   import { startsWith, resolve, shouldNavigate } from "./utils.js";
 
   export let to = "#";
@@ -11,6 +10,7 @@
 
   const { base } = getContext(ROUTER);
   const location = getContext(LOCATION);
+  const { navigate } = getContext(HISTORY);
   const dispatch = createEventDispatcher();
 
   let href, isPartiallyCurrent, isCurrent, props;

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -3,7 +3,7 @@
   import { writable, derived } from "svelte/store";
   import { LOCATION, ROUTER } from "./contexts.js";
   import { globalHistory } from "./history.js";
-  import { pick, match, stripSlashes, combinePaths } from "./utils.js";
+  import { pick, match, combinePaths } from "./utils.js";
 
   export let basepath = "/";
   export let url = null;

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -1,12 +1,14 @@
 <script>
   import { getContext, setContext, onMount } from "svelte";
   import { writable, derived } from "svelte/store";
-  import { LOCATION, ROUTER } from "./contexts.js";
+  import { LOCATION, ROUTER, HISTORY } from "./contexts.js";
   import { globalHistory } from "./history.js";
   import { pick, match, combinePaths } from "./utils.js";
 
   export let basepath = "/";
   export let url = null;
+  export let history = globalHistory;
+  setContext(HISTORY, history);
 
   const locationContext = getContext(LOCATION);
   const routerContext = getContext(ROUTER);
@@ -19,7 +21,7 @@
   // If the `url` prop is given we force the location to it.
   const location =
     locationContext ||
-    writable(url ? { pathname: url } : globalHistory.location);
+    writable(url ? { pathname: url } : history.location);
 
   // If routerContext is set, the routerBase of the parent Router
   // will be the base for this Router's descendants.
@@ -108,8 +110,8 @@
     // The topmost Router in the tree is responsible for updating
     // the location store and supplying it through context.
     onMount(() => {
-      const unlisten = globalHistory.listen(history => {
-        location.set(history.location);
+      const unlisten = history.listen(event => {
+        location.set(event.location);
       });
 
       return unlisten;

--- a/src/contexts.js
+++ b/src/contexts.js
@@ -1,2 +1,3 @@
 export const LOCATION = {};
 export const ROUTER = {};
+export const HISTORY = {};


### PR DESCRIPTION
This exposes a param on the router called `history`. By default, it will use `globalHistory`, but we can pass an API-compatible history object and it will be used instead. For example, we can force it to use a memory source (closes #153):

```svelte
<script>
  import { Router, Link, Route } from "svelte-routing";
  import {
    createHistory,
    createMemorySource,
  } from "svelte-routing/src/history";
  // ...import routes...

  const source = createMemorySource();
  let url = source.location.pathname;
  const history = createHistory(source);
</script>

<Router url="{url}">
  <nav>
    <Link to="/">Home</Link>
    <Link to="about">About</Link>
    <Link to="blog">Blog</Link>
  </nav>
  <div>
    <Route path="blog/:id" component="{BlogPost}" />
    <Route path="blog" component="{Blog}" />
    <Route path="about" component="{About}" />
    <Route path="/"><Home /></Route>
  </div>
</Router>
```

I've also noticed that the History type is kinda like the [history](https://www.npmjs.com/package/history) package used in React Router – apart from `navigate` vs. `push`/`replace`, it seems like a drop-in replacement. You might want to switch to that instead, as it seems like a good abstraction overall – but that's up to you :) 