### PR TITLE
Expose let:location in router

### DIFF
--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -127,4 +127,4 @@
   });
 </script>
 
-<slot></slot>
+<slot location={$location}></slot>


### PR DESCRIPTION
This allows users to access the location in the Router component not under a Route, e.g, navigation components

```jsx
<Router let:location>
  <Navigation location={location} />
  <Route path='foo'>
   ...
</Router>
```