### PR TITLE
Treat route list as immutable

### DIFF
--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -72,17 +72,14 @@
       }
     } else {
       routes.update(rs => {
-        rs.push(route);
-        return rs;
+        return [ ...rs, route ];
       });
     }
   }
 
   function unregisterRoute(route) {
     routes.update(rs => {
-      const index = rs.indexOf(route);
-      rs.splice(index, 1);
-      return rs;
+      return rs.filter((r) => r !== route);
     });
   }
 
@@ -91,9 +88,11 @@
   $: {
     const { path: basepath } = $base;
     routes.update(rs => {
-      rs.forEach(r => (r.path = combinePaths(basepath, r._path)));
-      return rs;
-    });
+      return rs.map((r) => ({
+        ...r,
+        path: combinePaths(basepath, r._path)
+      }));
+    });      
   }
   // This reactive statement will be run when the Router is created
   // when there are no Routes and then again the following tick, so it


### PR DESCRIPTION
As discussed in #131, the handling of the `routes` array [in this chunk of code](https://github.com/EmilTholin/svelte-routing/blob/9f6b36cfa6132a96b62568005431b71d8966fb32/src/Router.svelte#L74-L97) is imperative - data is mutated in place. This results in trouble if the [`immutable` option](https://svelte.dev/docs#svelte_compile) is used with the Svelte compiler.

This PR fixes the problem by using functional techniques to handle changes to the `routes` array. The changes are not of consequence to any other part of code, and I have tested them in my project and found that everything works correctly with `immutable` with these changes in place.

Btw, I also checked for other instances where arrays are modified in place, and I found them [here](https://github.com/EmilTholin/svelte-routing/blob/9f6b36cfa6132a96b62568005431b71d8966fb32/src/utils.js#L297-L307) and [here](https://github.com/EmilTholin/svelte-routing/blob/9f6b36cfa6132a96b62568005431b71d8966fb32/src/history.js#L16-L38). I decided not to change these because the arrays in question are only used internally as far as I can see, and their handling should not influence reactive Svelte code. I didn't want to make more changes than necessary to address issue #131.