### PR TITLE
replace deprecated packages in example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,6 @@
     "nodemon": "^2.0.6",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.35.1",
-    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-svelte": "~7.0.0",
     "rollup-plugin-terser": "^7.0.2",
@@ -19,6 +18,7 @@
     "server": "nodemon server.js --watch server.js --watch public/App.js"
   },
   "devDependencies": {
-    "rollup-plugin-node-resolve": "^5.2.0"
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.0"
   }
 }

--- a/example/rollup.config.js
+++ b/example/rollup.config.js
@@ -1,6 +1,6 @@
 import svelte from "rollup-plugin-svelte";
-import resolve from "rollup-plugin-node-resolve";
-import commonjs from "rollup-plugin-commonjs";
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
 import livereload from "rollup-plugin-livereload";
 import { terser } from "rollup-plugin-terser";
 


### PR DESCRIPTION
These two packages have been deprecated, so they should be replaced with `@rollup/plugin-commonjs`  and `@rollup/plugin-node-resolve`.

ref:
https://www.npmjs.com/package/rollup-plugin-commonjs
https://www.npmjs.com/package/rollup-plugin-node-resolve