### PR TITLE
types: add typedefs for `src/history`

### DIFF
--- a/types/ambient.d.ts
+++ b/types/ambient.d.ts
@@ -1,5 +1,5 @@
 declare module 'svelte-routing/src/history' {
-  const getLocation: (source: typeof window) => typeof window & { state: any; key: any };
+  const getLocation: (source: typeof window) => Location & { state: any; key: any };
 
   type Listener = (params: {
     location: ReturnType<typeof getLocation>;

--- a/types/ambient.d.ts
+++ b/types/ambient.d.ts
@@ -1,0 +1,33 @@
+declare module 'svelte-routing/src/history' {
+  const getLocation: (source: typeof window) => typeof window & { state: any; key: any };
+
+  type Listener = (params: {
+    location: ReturnType<typeof getLocation>;
+    action: 'POP' | 'PUSH';
+  }) => void;
+
+  export const createHistory: (source: typeof window) => {
+    readonly location: ReturnType<typeof getLocation>;
+    listen: (listener: Listener) => () => void;
+    navigate: (to?: string | null, options?: { replace: boolean; state: any }) => void;
+  };
+
+  type StackItem = { pathname: string; search: string };
+
+  export const createMemorySource: (initialPathname?: string) => {
+    readonly location: StackItem;
+    // These functions seem to have no implimentation
+    // addEventListener: typeof window.addEventListener
+    // removeEventListener: typeof window.removeEventListener
+    history: {
+      readonly entries: StackItem[];
+      readonly index: number;
+      readonly state: any;
+      pushState: (state: any, _: unknown, uri: string) => void;
+      replaceState: (state: any, _: unknown, uri: string) => void;
+    };
+  };
+
+  export const globalHistory: ReturnType<typeof createHistory>;
+  export const navigate: ReturnType<typeof createHistory>['navigate'];
+}

--- a/types/ambient.d.ts
+++ b/types/ambient.d.ts
@@ -1,5 +1,5 @@
 declare module 'svelte-routing/src/history' {
-  const getLocation: (source: typeof window) => Location & { state: any; key: any };
+  const getLocation: (source: typeof window) => Location & { state: any; key: string };
 
   type Listener = (params: {
     location: ReturnType<typeof getLocation>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="./ambient" />
+
 export { Router } from './Router';
 export { Route } from './Route';
 export { Link } from './Link';


### PR DESCRIPTION
- Adds type definitions for `"svelte-routing/src/history"`

I wanted to use the code from https://github.com/EmilTholin/svelte-routing/issues/62#issuecomment-760151657, but there weren't type definitions for `"svelte-routing/src/history"`