### PR TITLE
Pass existing props to Link.getProps

### DIFF
--- a/example/src/components/NavLink.svelte
+++ b/example/src/components/NavLink.svelte
@@ -3,14 +3,15 @@
 
   export let to = "";
 
-  function getProps({ location, href, isPartiallyCurrent, isCurrent }) {
+  function getProps({ location, href, isPartiallyCurrent, isCurrent, existingProps }) {
     const isActive = href === "/" ? isCurrent : isPartiallyCurrent || isCurrent;
 
-    // The object returned here is spread on the anchor element's attributes
+    let classNames = existingProps.class || '';
     if (isActive) {
-      return { class: "active" };
+      classNames += ' active';
     }
-    return {};
+
+    return { class: classNames };
   }
 </script>
 

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -22,7 +22,8 @@
     location: $location,
     href,
     isPartiallyCurrent,
-    isCurrent
+    isCurrent,
+    existingProps: $$restProps
   });
 
   function onClick(event) {


### PR DESCRIPTION
Hi, please take a look and let me knows if this makes sense to land :)

This adds a fifth field `existingProps` to `getProps`, which passes down the existing props defined on the Link element. This seems to make Link-based components a bit more reuseable since now we can keep existing props that are passed down (eg. `<NavLink class="nav-item">` could simply append `active` to the existing classes). I updated the example to clarify.

Thanks!