### PR TITLE
Important fix regarding (nested) routing

### DIFF
--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -81,10 +81,7 @@
     $: {
         const { path: basepath } = $base;
         routes.update((rs) =>
-            rs.map((r) => ({
-                ...r,
-                path: combinePaths(basepath, r._path),
-            }))
+            rs.map((r) => Object.assign(r, { path: combinePaths(basepath, r._path) }))
         );
     }
     // This reactive statement will be run when the Router is created


### PR DESCRIPTION
This PR fixes an issue when using nested routing by preventing new route object instances from being created, which causes this check https://github.com/EmilTholin/svelte-routing/blob/master/src/Route.svelte#L42 to evaluate to false, although all properties of the compared route objects are equal. This bug was introduced with version 1.8.

Would love to see this being merged as soon as possible. Thanks in advance!

Best
Philipp