### PR TITLE
Bump to svelte4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 yarn.lock
 example/public/*
 !example/public/global.css
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte-routing",
-    "version": "1.10.0",
+    "version": "2.0.0",
     "author": "Emil Tholin @EmilTholin",
     "license": "MIT",
     "description": "A declarative Svelte routing library with SSR support",
@@ -20,6 +20,6 @@
     "types": "types/index.d.ts",
     "svelte": "src/index.js",
     "devDependencies": {
-        "svelte": "^3.59.1"
+        "svelte": "^4.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte-routing",
-    "version": "2.0.0",
+    "version": "1.10.0",
     "author": "Emil Tholin @EmilTholin",
     "license": "MIT",
     "description": "A declarative Svelte routing library with SSR support",

--- a/types/Link.d.ts
+++ b/types/Link.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponentTyped } from "svelte";
+import { SvelteComponent } from "svelte";
 import { RouteLocation } from "./Route";
 
 type LinkProps = {
@@ -17,7 +17,7 @@ type GetPropsParams = {
     isCurrent: boolean;
 };
 
-export class Link extends SvelteComponentTyped<
+export class Link extends SvelteComponent<
     Omit<
         LinkProps &
             svelte.JSX.HTMLProps<HTMLAnchorElement> &

--- a/types/Route.d.ts
+++ b/types/Route.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponent, SvelteComponentTyped } from "svelte";
+import { SvelteComponent } from "svelte";
 
 type AsyncSvelteComponent = () => Promise<{
     default: typeof SvelteComponent;
@@ -30,7 +30,7 @@ type RouteParams = {
     [param: string]: string;
 };
 
-export class Route extends SvelteComponentTyped<
+export class Route extends SvelteComponent<
     RouteProps,
     Record<string, any>,
     RouteSlots

--- a/types/Router.d.ts
+++ b/types/Router.d.ts
@@ -1,8 +1,8 @@
-import { SvelteComponentTyped } from "svelte";
+import { SvelteComponent } from "svelte";
 
 type RouterProps = {
     basepath?: string;
     url?: string;
 };
 
-export class Router extends SvelteComponentTyped<RouterProps> {}
+export class Router extends SvelteComponent<RouterProps> {}


### PR DESCRIPTION
This pr updates `package.json` to require svelte4 and replaces `SvelteComponentTyped`, which is now deprecated in svelte4, with `SvelteComponent` directly instead, as suggested by the svelte authors.

Feel free to make any edits to the pr.