### PR TITLE
fix: Correct type declaration for context hooks

### DIFF
--- a/types/contexts.d.ts
+++ b/types/contexts.d.ts
@@ -6,6 +6,6 @@ type LOCATION = RouteLocation;
 type ROUTER = RouterProps;
 type HISTORY = Record<string | number, any>;
 
-export const useLocation: () => typeof getContext<LOCATION>;
-export const useRouter: () => typeof getContext<ROUTER>;
-export const useHistory: () => typeof getContext<HISTORY>;
+export const useLocation: () => ReturnType<typeof getContext<LOCATION>>;
+export const useRouter: () => ReturnType<typeof getContext<ROUTER>>;
+export const useHistory: () => ReturnType<typeof getContext<HISTORY>>;

--- a/types/contexts.d.ts
+++ b/types/contexts.d.ts
@@ -1,4 +1,4 @@
-import { getContext } from "svelte";
+import { readable } from "svelte/store";
 import { RouteLocation } from "./Route";
 import { RouterProps } from "./Router";
 
@@ -6,6 +6,6 @@ type LOCATION = RouteLocation;
 type ROUTER = RouterProps;
 type HISTORY = Record<string | number, any>;
 
-export const useLocation: () => ReturnType<typeof getContext<LOCATION>>;
-export const useRouter: () => ReturnType<typeof getContext<ROUTER>>;
-export const useHistory: () => ReturnType<typeof getContext<HISTORY>>;
+export const useLocation: () => ReturnType<typeof readable<LOCATION>>;
+export const useRouter: () => ReturnType<typeof readable<ROUTER>>;
+export const useHistory: () => ReturnType<typeof readable<HISTORY>>;


### PR DESCRIPTION
Type definitions of `useLocation`, `useRouter`, and `useHistory` were defined as getContext functions as in fact they are writables.

Simply changing declaration to `ReturnType<typeof readable<...>>` fixes the issue.