### PR TITLE
Fix type of component prop of Route

### DIFF
--- a/types/Route.d.ts
+++ b/types/Route.d.ts
@@ -1,12 +1,12 @@
 import { SvelteComponent } from "svelte";
 
 type AsyncSvelteComponent = () => Promise<{
-    default: typeof SvelteComponent;
+    default: typeof SvelteComponent<any>;
 }>;
 
 type RouteProps = {
     path?: string;
-    component?: typeof SvelteComponent | AsyncSvelteComponent;
+    component?: typeof SvelteComponent<any> | AsyncSvelteComponent;
     [additionalProp: string]: unknown;
 };
 


### PR DESCRIPTION
Assigning any component to a route using Svelte 4
```
<Router>
  <Route component={ Info } />
</Router>
```
results in a typescript error
```
Error: Type 'typeof Info__SvelteComponent_' is not assignable to type 'typeof SvelteComponent | AsyncSvelteComponent'.
  Type 'typeof Info__SvelteComponent_' is not assignable to type 'typeof SvelteComponent'.
    Types of construct signatures are incompatible.
      Type 'new (options: ComponentConstructorOptions<Record<string, never>>) => Info__SvelteComponent_' is not assignable to type 'new <Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any>(options: ComponentConstructorOptions<Props>) => SvelteComponent<...>'.
        Types of parameters 'options' and 'options' are incompatible.
          Type 'ComponentConstructorOptions<Props>' is not assignable to type 'ComponentConstructorOptions<Record<string, never>>'.
            Type 'Props' is not assignable to type 'Record<string, never>'.
              Type 'Record<string, any>' is not assignable to type 'Record<string, never>'.
                'string' index signatures are incompatible.
                  Type 'any' is not assignable to type 'never'. (ts)
```

SvelteComponent in Svelte 4 behaves as SvelteComponenTyped and therefore `<any>` should be added to `typeof SvelteComponent`. For more details see https://github.com/sveltejs/svelte/pull/8512.