### PR TITLE
Fix README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm i -D svelte-routing
   import About from "./routes/About.svelte";
   import Blog from "./routes/Blog.svelte";
 
-  export let url = "/";
+  export let url = "";
 </script>
 
 <Router {url}>


### PR DESCRIPTION
Hi folks,

The example in the `Usage` section of the README uses `export let url = "/";`, which will always send the user to the home path.

This means that if the user navigates to a different route and reloads the page, instead of reloading the same component it will render the home again.

I think leaving it empty produces the behavior users expect.