### PR TITLE
Fix: Link getProps parameter implicitly has an 'any' type, issue #254

### DIFF
--- a/types/Link.d.ts
+++ b/types/Link.d.ts
@@ -1,4 +1,5 @@
 import { SvelteComponent } from "svelte";
+import { HTMLAnchorAttributes } from "svelte/elements";
 import { RouteLocation } from "./Route";
 
 type LinkProps = {
@@ -20,8 +21,7 @@ type GetPropsParams = {
 export class Link extends SvelteComponent<
     Omit<
         LinkProps &
-            svelte.JSX.HTMLProps<HTMLAnchorElement> &
-            svelte.JSX.SapperAnchorProps,
+        HTMLAnchorAttributes,
         "href"
     >
 > {}


### PR DESCRIPTION
Fix: Link getProps parameter implicitly has an 'any' type, svelte 4.1.2, typescript 5.1.6, issue #254