### PR TITLE
Add preserveScroll option to navigate(), Link component and link(s) action

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ A component used to navigate around the application.
 
 ###### Properties
 
-|  Property  | Required | Default Value | Description                                                                                                                                                                                                                           |
-| :--------: | :------: | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|    `to`    |   ✔ ️    |     `"#"`     | URL the component should link to.                                                                                                                                                                                                     |
-| `replace`  |          |    `false`    | When `true`, clicking the `Link` will replace the current entry in the history stack instead of adding a new one.                                                                                                                     |
-|  `state`   |          |     `{}`      | An object that will be pushed to the history stack when the `Link` is clicked.                                                                                                                                                        |
-| `getProps` |          | `() => ({})`  | A function that returns an object that will be spread on the underlying anchor element's attributes. The first argument given to the function is an object with the properties `location`, `href`, `isPartiallyCurrent`, `isCurrent`. |
+|     Property     | Required | Default Value | Description                                                                                                                                                                                                                           |
+|:----------------:| :------: | :-----------: |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|       `to`       |   ✔ ️    |     `"#"`     | URL the component should link to.                                                                                                                                                                                                     |
+|    `replace`     |          |    `false`    | When `true`, clicking the `Link` will replace the current entry in the history stack instead of adding a new one.                                                                                                                     |
+|     `state`      |          |     `{}`      | An object that will be pushed to the history stack when the `Link` is clicked.                                                                                                                                                        |
+|    `getProps`    |          | `() => ({})`  | A function that returns an object that will be spread on the underlying anchor element's attributes. The first argument given to the function is an object with the properties `location`, `href`, `isPartiallyCurrent`, `isCurrent`. |
+| `preserveScroll` |          |    `false`    | When `true`, clicking the `Link` will scroll the page to the top.                                                                                                                                                                     |
 
 #### `Route`
 
@@ -125,7 +126,7 @@ those use cases where a `Link` component is not suitable, e.g. after submitting
 a form.
 
 The first argument is a string denoting where to navigate to, and the second
-argument is an object with a `replace` and `state` property equivalent to those
+argument is an object with a `replace`, `state` and `preserveScroll` properties equivalent to those
 in the `Link` component.
 
 ```html
@@ -144,7 +145,7 @@ in the `Link` component.
 
 An action used on anchor tags to navigate around the application. You can add an
 attribute `replace` to replace the current entry in the history stack instead of
-adding a new one.
+adding a new one and `preserveScroll` to not scroll the page to the top when clicked.
 
 ```html
 <script>
@@ -162,7 +163,8 @@ adding a new one.
 
 An action used on a root element to make all relative anchor elements navigate
 around the application. You can add an attribute `replace` on any anchor to
-replace the current entry in the history stack instead of adding a new one. You
+replace the current entry in the history stack instead of adding a new one.
+You can add an attribute `preserveScroll` on any anchor to not to scroll the page to the top when clicked. You
 can add an attribute `noroute` for this action to skip over the anchor and allow
 it to use the native browser action.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A component used to navigate around the application.
 |    `replace`     |          |    `false`    | When `true`, clicking the `Link` will replace the current entry in the history stack instead of adding a new one.                                                                                                                     |
 |     `state`      |          |     `{}`      | An object that will be pushed to the history stack when the `Link` is clicked.                                                                                                                                                        |
 |    `getProps`    |          | `() => ({})`  | A function that returns an object that will be spread on the underlying anchor element's attributes. The first argument given to the function is an object with the properties `location`, `href`, `isPartiallyCurrent`, `isCurrent`. |
-| `preserveScroll` |          |    `false`    | When `true`, clicking the `Link` will scroll the page to the top.                                                                                                                                                                     |
+| `preserveScroll` |          |    `false`    | When `true`, clicking the `Link` will not scroll the page to the top.                                                                                                                                                                 |
 
 #### `Route`
 

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -7,6 +7,7 @@
     export let replace = false;
     export let state = {};
     export let getProps = () => ({});
+    export let preserveScroll = false;
 
     const location = getContext(LOCATION);
     const { base } = getContext(ROUTER);
@@ -33,7 +34,7 @@
             // Don't push another entry to the history stack when the user
             // clicks on a Link to the page they are currently on.
             const shouldReplace = $location.pathname === href || replace;
-            navigate(href, { state, replace: shouldReplace });
+            navigate(href, { state, replace: shouldReplace, preserveScroll });
         }
     };
 </script>

--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -29,7 +29,7 @@
             else component = c();
         }
 
-        canUseDOM() && window?.scrollTo(0, 0);
+       canUseDOM() && !$activeRoute.preserveScroll && window?.scrollTo(0, 0);
     }
 
     registerRoute(route);

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -101,7 +101,7 @@
         // the location store and supplying it through context.
         onMount(() => {
             const unlisten = history.listen((event) => {
-								preserveScroll = event.preserveScroll || false;
+                preserveScroll = event.preserveScroll || false;
                 location.set(event.location);
             });
 

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -76,6 +76,9 @@
     const unregisterRoute = (route) => {
         routes.update((rs) => rs.filter((r) => r !== route));
     };
+
+		let preserveScroll = false;
+
     // This reactive statement will update all the Routes' path when
     // the basepath changes.
     $: {
@@ -90,7 +93,7 @@
     // pick an active Route after all Routes have been registered.
     $: {
         const bestMatch = pick($routes, $location.pathname);
-        activeRoute.set(bestMatch);
+        activeRoute.set({...bestMatch, preserveScroll});
     }
 
     if (!locationContext) {
@@ -98,6 +101,7 @@
         // the location store and supplying it through context.
         onMount(() => {
             const unlisten = history.listen((event) => {
+								preserveScroll = event.preserveScroll || false;
                 location.set(event.location);
             });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -22,6 +22,7 @@ const link = (node) => {
             event.preventDefault();
             navigate(anchor.pathname + anchor.search, {
                 replace: anchor.hasAttribute("replace"),
+                preserveScroll: anchor.hasAttribute("preserveScroll"),
             });
         }
     };
@@ -70,6 +71,7 @@ const links = (node) => {
             event.preventDefault();
             navigate(anchor.pathname + anchor.search, {
                 replace: anchor.hasAttribute("replace"),
+                preserveScroll: anchor.hasAttribute("preserveScroll"),
             });
         }
     };

--- a/src/history.js
+++ b/src/history.js
@@ -37,7 +37,7 @@ const createHistory = (source) => {
             };
         },
 
-        navigate(to, { state, replace = false } = {}) {
+        navigate(to, { state, replace = false, preserveScroll = false } = {}) {
             state = { ...state, key: Date.now() + "" };
             // try...catch iOS Safari limits to 100 pushState calls
             try {
@@ -48,7 +48,7 @@ const createHistory = (source) => {
             }
             location = getLocation(source);
             listeners.forEach((listener) =>
-                listener({ location, action: "PUSH" })
+                listener({ location, action: "PUSH", preserveScroll })
             );
             document.activeElement.blur();
         },

--- a/types/Link.d.ts
+++ b/types/Link.d.ts
@@ -5,6 +5,7 @@ import { RouteLocation } from "./Route";
 type LinkProps = {
     to: string;
     replace?: boolean;
+    preserveScroll?: boolean;
     state?: {
         [k in string | number]: unknown;
     };

--- a/types/ambient.d.ts
+++ b/types/ambient.d.ts
@@ -13,7 +13,7 @@ declare module "svelte-routing/src/history" {
         listen: (listener: Listener) => () => void;
         navigate: (
             to?: string | null,
-            options?: { replace: boolean; state: any }
+            options?: { replace: boolean; preserveScroll: boolean; state: any }
         ) => void;
     };
 

--- a/types/functions.d.ts
+++ b/types/functions.d.ts
@@ -3,10 +3,12 @@ export const navigate: (
     {
         replace,
         state,
+        preserveScroll,
     }?: {
         replace?: boolean;
         state?: {
             [k in string | number]: unknown;
-        };
+        },
+        preserveScroll?: boolean;
     }
 ) => void;


### PR DESCRIPTION
In version 1.8.9 (d8fe086df6c0034930da2cd51c2d403d0739965c), an unconditional scroll to the top after the changing location has been added. However, in some situations this is not desirable behavior. For example, if one of the components on a page changes state and you don't want the page to be scrolled, but you need to reflect that state change in the URL so that user can share a link or keep the change when they refresh the page.

This PR adds an optional `preserveScroll` parameter to navigate(), Link component and link/links actions, so you can get this behavior. By default it has a value of `false` so it does not change the current behavior. Of course, the README has also been updated.
