### PR TITLE
build(package.json): Add exports field for Svelte compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "repository": "EmilTholin/svelte-routing",
     "main": "src/index.js",
     "types": "types/index.d.ts",
-    "svelte": "src/index.js",
+    "exports": {
+      ".": {
+        "svelte": "src/index.js"
+      }
+    },
     "devDependencies": {
         "svelte": "^4.2.2",
         "prettier": "^3.0.3",


### PR DESCRIPTION
In `@sveltejs/vite-plugin-svelte@3.0.0`, the `package.json` entrypoint `svelte` is deprecated.

ref: [missing exports condition](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition)