### PR TITLE
Adding an option for blurring the document's active element on `navigate` method

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -37,7 +37,7 @@ const createHistory = (source) => {
             };
         },
 
-        navigate(to, { state, replace = false, preserveScroll = false } = {}) {
+        navigate(to, { state, replace = false, preserveScroll = false, blurActiveElement = true } = {}) {
             state = { ...state, key: Date.now() + "" };
             // try...catch iOS Safari limits to 100 pushState calls
             try {
@@ -50,7 +50,7 @@ const createHistory = (source) => {
             listeners.forEach((listener) =>
                 listener({ location, action: "PUSH", preserveScroll })
             );
-            document.activeElement.blur();
+            if(blurActiveElement) document.activeElement.blur();
         },
     };
 };


### PR DESCRIPTION
In some cases, blurring the active element when using the `navigate` can lead to undesired behaviours.
For exemple, if a list component uses a select menu that natively closes on blur, then the menu will close every time we push new params to the current location.

To resolve this issue, I've added an optional arg `blurActiveElement` to the `navigate` options arg. 
It is defaulted to `true` to avoid any breaking changes.