### PR TITLE
Add missing blurActiveElement prop to types

### DIFF
--- a/types/functions.d.ts
+++ b/types/functions.d.ts
@@ -10,5 +10,6 @@ export const navigate: (
             [k in string | number]: unknown;
         };
         preserveScroll?: boolean;
+        blurActiveElement?: boolean;
     }
 ) => void;


### PR DESCRIPTION
Given https://github.com/EmilTholin/svelte-routing/blob/950e752c9292324278500162c0b0a7fb1b64b8aa/src/history.js#L40

This PR adds a missing prop to the typescript type interface. 
`blurActiveElement` is accepted by the js implementation, but was missing in the ts interface.