### PR TITLE
Remove special case. It seems to just break SSR.

### DIFF
--- a/src/Route.svelte
+++ b/src/Route.svelte
@@ -24,11 +24,6 @@
         const { component: c, path, ...rest } = $$props;
         routeProps = rest;
 
-        if (c) {
-            if (c.toString().startsWith("class ")) component = c;
-            else component = c();
-        }
-
         canUseDOM() && !$activeRoute.preserveScroll && window?.scrollTo(0, 0);
     }
 


### PR DESCRIPTION
I'm not 100% sure this is consistent with every way this might be used, but I ran into basically the same bug as #244, except I'm not using `vite-plugin-ssr`.

Note that I am on Svelte 4. (4.2.17)
