### PR TITLE
Removed out directive for viewtransition function

### DIFF
--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -133,7 +133,7 @@
 
 {#if viewtransition}
     {#key $location.pathname}
-        <div in:viewtransitionFn out:viewtransitionFn>
+        <div in:viewtransitionFn>
             <slot
                 route={$activeRoute && $activeRoute.uri}
                 location={$location}


### PR DESCRIPTION
Hi, I'd like to propose that the ```out``` directive be removed for the viewtransition function for transitions on navigation.

Currently, when navigating between routes and when using the ```fade``` transition from "svelte/transition", both the old and new incoming route components immediately become visible and are relatively, vertically "stacked." One routes' components are above and the other's below, potentially increasing the page height. Then both fade out concurrently for the duration set, with the 'fade in' seemingly having no effect.

Alternatively, if removing of the ```out``` directive is not ideal and there are use cases for other transitions where both the ```in``` and ```out``` directives are necessary, another approach could be to pass an additional key/value in the viewtransition prop object like:

`viewtransition="{() => ({ fn: fade, duration: 500, inOnly: true })}"`

Where in this case we could delineate either ```inOnly: true```, ```outOnly: true``` or simply omit the field to maintain the current implementation.

Taking this approach, the new ```viewtransitionFn``` could look something like:
```
const viewtransitionFn = (node, _, direction) => {
    const vt = viewtransition(direction);
    if (typeof vt?.fn === "function") {
        if (vt?.inOnly && direction.direction === "out") {
            vt.duration = 0;
        } else if (vt?.outOnly && direction.direction === "in") {
            vt.duration = 0;
        }
        return vt.fn(node, vt);
    } else return vt;
};
```
In this approach, when choosing to use only the ```in``` or ```out``` directive, the duration of the opposite directive is set to 0, essentially removing its effect.

Would love to know what you think! Happy to make another a PR for the latter approach if necessary. Thank you!
